### PR TITLE
Add JSON logging handler

### DIFF
--- a/namwoo_app/__init__.py
+++ b/namwoo_app/__init__.py
@@ -3,7 +3,8 @@ import os
 import logging
 from logging.config import dictConfig
 from flask import Flask
-from .config.config import Config # Your Config class
+from .config.config import Config
+from .utils.logging_utils import JsonFormatter
 
 # --- Logging Configuration (Your original logging setup - Kept as is) ---
 log_level_env = os.environ.get('LOG_LEVEL', 'INFO').upper()
@@ -17,6 +18,10 @@ logging_config = {
     'formatters': {
         'standard': {
             'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s',
+            'datefmt': '%Y-%m-%d %H:%M:%S'
+        },
+        'json': {
+            '()': JsonFormatter,
             'datefmt': '%Y-%m-%d %H:%M:%S'
         },
     },
@@ -44,20 +49,29 @@ logging_config = {
             'maxBytes': 5242880,
             'backupCount': 3,
             'encoding': 'utf8',
+        },
+        'json_file': {
+            'level': log_level_env,
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'json',
+            'filename': getattr(Config, 'LOG_JSON_FILE', os.path.join(log_dir_path, 'app.json')),
+            'maxBytes': 10485760,
+            'backupCount': 5,
+            'encoding': 'utf8',
         }
     },
     'loggers': {
-        '': { 
-            'handlers': ['console', 'app_file'],
+        '': {
+            'handlers': ['console', 'app_file', 'json_file'],
             'level': log_level_env,
-            'propagate': True 
+            'propagate': True
         },
-        'werkzeug': {'handlers': ['console', 'app_file'], 'level': 'INFO', 'propagate': False,},
-        'sqlalchemy.engine': {'handlers': ['console', 'app_file'], 'level': 'WARNING','propagate': False,},
-        'apscheduler': {'handlers': ['console', 'app_file'], 'level': 'INFO', 'propagate': False,},
-        'sync': {'handlers': ['console', 'sync_file'], 'level': log_level_env, 'propagate': False,},
-        'celery': {'handlers': ['console', 'app_file'], 'level': log_level_env, 'propagate': False,},
-        'namwoo_app': {'handlers': ['console', 'app_file'], 'level': log_level_env, 'propagate': False}
+        'werkzeug': {'handlers': ['console', 'app_file', 'json_file'], 'level': 'INFO', 'propagate': False,},
+        'sqlalchemy.engine': {'handlers': ['console', 'app_file', 'json_file'], 'level': 'WARNING', 'propagate': False,},
+        'apscheduler': {'handlers': ['console', 'app_file', 'json_file'], 'level': 'INFO', 'propagate': False,},
+        'sync': {'handlers': ['console', 'sync_file', 'json_file'], 'level': log_level_env, 'propagate': False,},
+        'celery': {'handlers': ['console', 'app_file', 'json_file'], 'level': log_level_env, 'propagate': False,},
+        'namwoo_app': {'handlers': ['console', 'app_file', 'json_file'], 'level': log_level_env, 'propagate': False}
     }
 }
 dictConfig(logging_config)

--- a/namwoo_app/config/config.py
+++ b/namwoo_app/config/config.py
@@ -23,6 +23,7 @@ class Config:
     os.makedirs(LOG_DIR, exist_ok=True)
     LOG_FILE = os.path.join(LOG_DIR, 'app.log')
     SYNC_LOG_FILE = os.path.join(LOG_DIR, 'sync.log')
+    LOG_JSON_FILE = os.path.join(LOG_DIR, 'app.json')
 
     # --- LLM Configuration ---
     LLM_PROVIDER = os.environ.get('LLM_PROVIDER', 'openai').lower()

--- a/namwoo_app/utils/logging_utils.py
+++ b/namwoo_app/utils/logging_utils.py
@@ -1,0 +1,14 @@
+import logging
+import json
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as JSON with timestamp and level."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_entry = {
+            "timestamp": self.formatTime(record, self.datefmt or "%Y-%m-%d %H:%M:%S"),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        return json.dumps(log_entry)


### PR DESCRIPTION
## Summary
- implement `JsonFormatter` for JSON log output
- record logs into `app.json` via new handler
- expose `LOG_JSON_FILE` in Config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685487802d2c832b82add77a7e09d690